### PR TITLE
Fix onClose calls for shared subscribers

### DIFF
--- a/src/lib/use-websocket.test.ts
+++ b/src/lib/use-websocket.test.ts
@@ -272,7 +272,44 @@ test('shared websockets each have callbacks invoked as if unshared', async (done
   done();
 })
 
-test('Options#fromSocketIO changes the WS url to support socket.io\'s required query params', async (done) => {
+
+test('shared websockets have their onClose callbacks invoked when all subscriber components disconnect', async (done) => {
+  const initialProps = { initialValue: true };
+  const onCloseFn1 = jest.fn();
+  const onCloseFn2 = jest.fn();
+  const onCloseFn3 = jest.fn();
+
+  const { rerender: rerender1 } = renderHook(
+    ({ initialValue }) => useWebSocket(URL, { share: true, onClose: onCloseFn1 }, initialValue),
+    { initialProps }
+  );
+  await server.connected;
+
+  const { rerender: rerender2 } = renderHook(
+    ({ initialValue }) => useWebSocket(URL, { share: true, onClose: onCloseFn2 }, initialValue),
+    { initialProps }
+  );
+  await server.connected;
+
+  const { rerender: rerender3 } = renderHook(
+    ({ initialValue }) => useWebSocket(URL, { share: true, onClose: onCloseFn3 }, initialValue),
+    { initialProps }
+  );
+  await server.connected;
+
+  rerender1({ initialValue: false });
+  rerender2({ initialValue: false });
+  rerender3({ initialValue: false });
+
+  await sleep(500);
+
+  expect(onCloseFn1).toHaveBeenCalledTimes(1);
+  expect(onCloseFn2).toHaveBeenCalledTimes(1);
+  expect(onCloseFn3).toHaveBeenCalledTimes(1);
+  done();
+});
+
+test("Options#fromSocketIO changes the WS url to support socket.io's required query params", async (done) => {
   options.fromSocketIO = true;
 
   const {


### PR DESCRIPTION
The missing calls to the option-based `onClose` handlers happen when shared subscribers that once had the `connect` flag enabled (thus that had mounted the main `useEffect`) later change them to `false` (in order to request unsubscription).

In that case `useEffect` is re-run, thus performing the cleanup function for the `connect` branch, where 2 issues existed:

1. the registration of the `onClose` handler for each subscriber happened only for the last component unsubscribing for a URL (i.e. only after`!hasSubscribers(url)` in `cleanSubscribers`). The order depends on which components un-mounts last, e.g. only a parent's `onClose` listener would be registered, and later run when `socketLike.close()` is called.
1. the event register for each subscriber was replacing any existing one, instead of adding to with `addEventListener`

It can be reproduced either in:
- https://codepen.io/davilima6-the-lessful/pen/xxLQLyy
- https://github.com/davilima6/react-use-websocket-example/

PS: I didn't understand why a complementary mechanism is needed to register the `onClose` handler, apart from the notifications-based one registered in `attach-shared-listeners#bindCloseHandler`, like it works for all other listeners.